### PR TITLE
Prevent UB when righ/left shifting large char values

### DIFF
--- a/firmware/cc1110/minimed_rf.c
+++ b/firmware/cc1110/minimed_rf.c
@@ -95,7 +95,7 @@ unsigned char packetOverflowCount = 0;
 unsigned char bufferOverflowCount = 0;
 
 int symbolInputBitCount = 0;
-int symbolOutputBuffer = 0;
+unsigned int symbolOutputBuffer = 0;
 int symbolOutputBitCount = 0;
 int symbolErrorCount = 0;
 
@@ -119,7 +119,7 @@ unsigned char XDATA(0xf5a8) radioOutputBuffer[256];
 // Symbol decoding - 53 bytes + 1 pad 
 unsigned char XDATA(0xf572) symbolTable[] = {16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 16, 11, 16, 13, 14, 16, 16, 16, 16, 16, 16, 0, 7, 16, 16, 9, 8, 16, 15, 16, 16, 16, 16, 16, 16, 3, 16, 5, 6, 16, 16, 16, 10, 16, 12, 16, 16, 16, 16, 1, 2, 16, 4};
 
-int symbolInputBuffer = 0;
+unsigned int symbolInputBuffer = 0;
 
 int timerCounter = 0;
 


### PR DESCRIPTION
If a symbol value like two 0xFF's come in( symbolInputValue = (symbolInputValue << 8) + value)you will end up with a signed 0xFFFF which is negative and gives Undefined Behaviour later on.  Plus it doesn't make sense since we are just storing up to two unsigned chars at a time to extract the 6 bit value.
