### PR TITLE
Adding a podspec for the BLE + Packet files in the short-term

### DIFF
--- a/app/GlucoseLink/ConfigureViewController.m
+++ b/app/GlucoseLink/ConfigureViewController.m
@@ -75,7 +75,8 @@
 }
 
 - (void)viewWillDisappear:(BOOL)animated {
-  [self saveValues];
+    [super viewWillDisappear:animated];
+    [self saveValues];
 }
 
 - (void)viewDidAppear:(BOOL)animated {

--- a/app/GlucoseLink/MySentryPairingViewController.m
+++ b/app/GlucoseLink/MySentryPairingViewController.m
@@ -8,6 +8,7 @@
 
 #import "MySentryPairingViewController.h"
 #import "Config.h"
+#import "MinimedPacket.h"
 #import "NSData+Conversion.h"
 #import "RileyLinkBLEManager.h"
 

--- a/app/GlucoseLink/RileyLinkBLEDevice.m
+++ b/app/GlucoseLink/RileyLinkBLEDevice.m
@@ -7,6 +7,7 @@
 //
 
 #import <CoreBluetooth/CoreBluetooth.h>
+#import "MinimedPacket.h"
 #import "RileyLinkBLEDevice.h"
 #import "RileyLinkBLEManager.h"
 #import "NSData+Conversion.h"
@@ -77,7 +78,7 @@
 
 - (void) triggerSend {
   if (copiesLeftToSend > 0) {
-    NSLog(@"Sending copy %d", (currentSendTask.repeatCount - copiesLeftToSend) + 1);
+    NSLog(@"Sending copy %ld", (currentSendTask.repeatCount - copiesLeftToSend) + 1);
     NSData *trigger = [NSData dataWithHexadecimalString:@"01"];
     [self.myPeripheral writeValue:trigger forCharacteristic:txTriggerCharacteristic type:CBCharacteristicWriteWithResponse];
     copiesLeftToSend--;

--- a/app/GlucoseLink/RileyLinkBLEManager.h
+++ b/app/GlucoseLink/RileyLinkBLEManager.h
@@ -7,7 +7,6 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "MinimedPacket.h"
 #import "RileyLinkBLEDevice.h"
 
 #define RILEY_LINK_EVENT_LIST_UPDATED        @"RILEY_LINK_EVENT_LIST_UPDATED"

--- a/app/GlucoseLink/RileyLinkBLEManager.m
+++ b/app/GlucoseLink/RileyLinkBLEManager.m
@@ -7,7 +7,6 @@
 //
 
 #import "RileyLinkBLEManager.h"
-#import "MinimedPacket.h"
 #import <CoreBluetooth/CoreBluetooth.h>
 #import "RileyLinkBLEDevice.h"
 

--- a/app/RileyLink.xcodeproj/project.pbxproj
+++ b/app/RileyLink.xcodeproj/project.pbxproj
@@ -602,6 +602,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				WARNING_CFLAGS = "-Wall";
 			};
 			name = Debug;
 		};
@@ -634,6 +635,7 @@
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
+				WARNING_CFLAGS = "-Wall";
 			};
 			name = Release;
 		};

--- a/rileylink.podspec
+++ b/rileylink.podspec
@@ -1,0 +1,129 @@
+#
+#  Be sure to run `pod spec lint rileylink.podspec' to ensure this is a
+#  valid spec and to remove all comments including this before submitting the spec.
+#
+#  To learn more about Podspec attributes see http://docs.cocoapods.org/specification.html
+#  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
+#
+
+Pod::Spec.new do |s|
+
+  # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  These will help people to find your library, and whilst it
+  #  can feel like a chore to fill in it's definitely to your advantage. The
+  #  summary should be tweet-length, and the description more in depth.
+  #
+
+  s.name         = "RileyLink"
+  s.version      = "0.1"
+  s.summary      = "Client adaptor for the RileyLink, a 916MHz to BLE bridge peripheral"
+
+  s.description  = <<-DESC
+                   RileyLink is a custom designed Bluetooth Smart (BLE) to 916MHz module. 
+                   It can be used to bridge any BLE capable smartphone to the world of 916Mhz based devices. 
+                   This project is focused on talking to Medtronic insulin pumps and sensors.
+                   
+                   Please understand that this project:
+
+                   * Has no affiliation with Medtronic
+                   * Is highly experimental
+                   * Is not intended for therapy
+                   DESC
+
+  s.homepage     = "https://github.com/ps2/rileylink"
+  # s.screenshots  = "www.example.com/screenshots_1.gif", "www.example.com/screenshots_2.gif"
+
+
+  # ―――  Spec License  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  Licensing your code is important. See http://choosealicense.com for more info.
+  #  CocoaPods will detect a license file if there is a named LICENSE*
+  #  Popular ones are 'MIT', 'BSD' and 'Apache License, Version 2.0'.
+  #
+
+  s.license      = { :type => "MIT", :file => "LICENSE" }
+
+
+  # ――― Author Metadata  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  Specify the authors of the library, with email addresses. Email addresses
+  #  of the authors are extracted from the SCM log. E.g. $ git log. CocoaPods also
+  #  accepts just a name if you'd rather not provide an email address.
+  #
+  #  Specify a social_media_url where others can refer to, for example a twitter
+  #  profile URL.
+  #
+
+  s.author             = "Pete Schwamb"
+
+  # ――― Platform Specifics ――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  If this Pod runs only on iOS or OS X, then specify the platform and
+  #  the deployment target. You can optionally include the target after the platform.
+  #
+
+  s.platform     = :ios, "7.0"
+
+  # ――― Source Location ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  Specify the location from where the source should be retrieved.
+  #  Supports git, hg, bzr, svn and HTTP.
+  #
+
+  s.source       = { :git => "https://github.com/ps2/rileylink.git", :branch => "master" }
+
+
+  # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  CocoaPods is smart about how it includes source code. For source files
+  #  giving a folder will include any swift, h, m, mm, c & cpp files.
+  #  For header files it will include any header in the folder.
+  #  Not including the public_header_files will make all headers public.
+  #
+
+  s.source_files  = "app/GlucoseLink/RileyLinkBLE*.{h,m}", "app/GlucoseLink/{MinimedPacket,NSData+Conversion,SendDataTask}.{h,m}"
+  # s.exclude_files = "Classes/Exclude"
+
+  s.public_header_files = "app/GlucoseLink/RileyLinkBLE*.h"
+
+
+  # ――― Resources ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  A list of resources included with the Pod. These are copied into the
+  #  target bundle with a build phase script. Anything else will be cleaned.
+  #  You can preserve files from being cleaned, please don't preserve
+  #  non-essential files like tests, examples and documentation.
+  #
+
+  # s.resource  = "icon.png"
+  # s.resources = "Resources/*.png"
+
+  # s.preserve_paths = "FilesToSave", "MoreFilesToSave"
+
+
+  # ――― Project Linking ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  Link your library with frameworks, or libraries. Libraries do not include
+  #  the lib prefix of their name.
+  #
+
+  s.framework  = "CoreBluetooth"
+  # s.frameworks = "SomeFramework", "AnotherFramework"
+
+  # s.library   = "iconv"
+  # s.libraries = "iconv", "xml2"
+
+
+  # ――― Project Settings ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  If your library depends on compiler flags you can set them in the xcconfig hash
+  #  where they will only apply to your library. If you depend on other Podspecs
+  #  you can include multiple dependencies to ensure it works.
+
+  # s.requires_arc = true
+
+  # s.xcconfig = { "HEADER_SEARCH_PATHS" => "$(SDKROOT)/usr/include/libxml2" }
+  # s.dependency "JSONKit", "~> 1.4"
+
+end


### PR DESCRIPTION
This should be totally benign, allowing others to link to these files while not forcing you into using cocoapods in your app. I'm not pushing this to the spec trunk, mostly because it's pointing to `master` and it still has all the template comments in the file.
